### PR TITLE
Switch deadline parameter for timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,10 @@ const test_proto = protoDescriptor.test;
 function main() {
   const client = new test_proto.Test('localhost:50052', grpc.credentials.createInsecure());
   
-  grpc_promise.promisifyAll(client, {timeout: 100}); // Optional timeout definition, defaults = 50
+  // Optional `timeout_message` out definition (defaults = 50)
+  // for the response of a single message of a bidirectional stream function in grpc.
+  // Don't confuse with `timeout` parameter used to set a deadline to the open connection.
+  grpc_promise.promisifyAll(client, { timeout_message: 100 });
     
   t = client.testStreamStream();
   t.sendMessage({})
@@ -492,11 +495,14 @@ main();
 
 ### Using Deadline
 
-The deadline parameter is used to to set a timestamp in millisenconds for the entire call to complete:
+The deadline parameter is used to to set a timestamp in millisenconds for the entire call to complete.
+For architectural reasons and knowing that the original deadline is passed as a timestamp,
+grpc-module forces to set a timeout parameter in milliseconds.
+It means the number of milliseconds we want to wait as most for the response:
 
 ```js
 // We give a deadline of 1 second (= 1000ms)
-grpc_promise.promisifyAll(client, deadline: Date.now() + 1000);
+grpc_promise.promisifyAll(client, { timeout: 1000 });
 ```
 
 ### Promisify single function

--- a/examples/client-bidi-stream.js
+++ b/examples/client-bidi-stream.js
@@ -23,7 +23,7 @@ function main() {
   meta.add('key', 'value');
 
   // Optional timeout definition, defaults = 50
-  grpc_promise.promisifyAll(client, { timeout: 100, metadata: meta, deadline: Date.now() + 1000 });
+  grpc_promise.promisifyAll(client, { timeout_message: 100, metadata: meta, timeout: 1000 }); // timeout in milliseconds
 
   let t = client.testStreamStream();
   t.sendMessage({})

--- a/examples/client-client-stream.js
+++ b/examples/client-client-stream.js
@@ -22,7 +22,7 @@ function main() {
   const meta = new grpc.Metadata();
   meta.add('key', 'value');
 
-  grpc_promise.promisifyAll(client, { metadata: meta, deadline: Date.now() + 1000 });
+  grpc_promise.promisifyAll(client, { metadata: meta, timeout: 1000 }); // timeout in milliseconds
 
   client.testStreamSimple(meta)
     .sendMessage({id: 1})

--- a/examples/client-promisify-only-one.js
+++ b/examples/client-promisify-only-one.js
@@ -22,7 +22,7 @@ function main() {
   const meta = new grpc.Metadata();
   meta.add('key', 'value');
 
-  grpc_promise.promisify(client, ['testSimpleSimple'], { metadata: meta, deadline: Date.now() + 1000 });
+  grpc_promise.promisify(client, ['testSimpleSimple'], { metadata: meta, timeout: 1000 }); // timeout in milliseconds
 
   client.testSimpleSimple()
     .sendMessage({id: 1})

--- a/examples/client-server-stream.js
+++ b/examples/client-server-stream.js
@@ -22,7 +22,7 @@ function main() {
   const meta = new grpc.Metadata();
   meta.add('key', 'value');
 
-  grpc_promise.promisifyAll(client, { metadata: meta, deadline: Date.now() + 1000 });
+  grpc_promise.promisifyAll(client, { metadata: meta, timeout: 1000 }); // timeout in milliseconds
 
   client.testSimpleStream()
     .sendMessage({id: 1})

--- a/examples/client-unary.js
+++ b/examples/client-unary.js
@@ -22,7 +22,7 @@ function main() {
   const meta = new grpc.Metadata();
   meta.add('key', 'value');
 
-  grpc_promise.promisifyAll(client, { metadata: meta, deadline: Date.now() + 1000 });
+  grpc_promise.promisifyAll(client, { metadata: meta, timeout: 1000 }); // timeout in milliseconds
 
   client.testSimpleSimple()
     .sendMessage({id: 1})

--- a/lib/request-types/bidi-stream-request.js
+++ b/lib/request-types/bidi-stream-request.js
@@ -9,8 +9,15 @@ class BidiStreamRequest {
     if (options == null) options = {};
     this.queue = {};
     this.correlationId = 0;
-    this.timeout = options.timeout || 50;
-    this.stream = original_function.call(client, options.metadata, { deadline: options.deadline });
+    this.timeout_message = options.timeout_message || 50;
+
+    // Deadline is advisable to be set
+    // It should be a timestamp value in milliseconds
+    let deadline = undefined;
+    if (options.timeout !== undefined) {
+      deadline = Date.now() + options.timeout;
+    }
+    this.stream = original_function.call(client, options.metadata, { deadline: deadline });
 
     this.stream.on('error', () => {});
     this.stream.on('data', data => {
@@ -51,7 +58,7 @@ class BidiStreamRequest {
         timeout: setTimeout(() => {
           delete this.queue[id];
           cb('timeout');
-        }, this.timeout)
+        }, this.timeout_message)
       };
       content['id'] = id;
       this.stream.write(content);

--- a/lib/request-types/client-stream-request.js
+++ b/lib/request-types/client-stream-request.js
@@ -4,13 +4,21 @@ class ClientStreamRequest {
   constructor (client, original_function, options = {}) {
     if (options == null) options = {};
     this.promise = new Promise((resolve, reject) => {
-      this.stream = original_function.call(client, options.metadata, { deadline: options.deadline }, function (error, response) {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(response);
+      // Deadline is advisable to be set
+      // It should be a timestamp value in milliseconds
+      let deadline = undefined;
+      if (options.timeout !== undefined) {
+        deadline = Date.now() + options.timeout;
+      }
+      this.stream = original_function.call(client, options.metadata, { deadline: deadline },
+        function (error, response) {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(response);
+          }
         }
-      });
+      );
     });
   }
 

--- a/lib/request-types/server-stream-request.js
+++ b/lib/request-types/server-stream-request.js
@@ -6,13 +6,19 @@ class ServerStreamRequest {
     this.queue = [];
     this.client = client;
     this.metadata = options.metadata;
-    this.deadline = options.deadline || undefined;
+    this.timeout = options.timeout || undefined;
     this.original_function = original_function;
   }
 
   sendMessage (content = {}) {
     return new Promise((resolve, reject) => {
-      this.stream = this.original_function.call(this.client, content, this.metadata, { deadline: this.deadline });
+      // Deadline is advisable to be set
+      // It should be a timestamp value in milliseconds
+      let deadline = undefined;
+      if (this.timeout !== undefined) {
+        deadline = Date.now() + this.timeout;
+      }
+      this.stream = this.original_function.call(this.client, content, this.metadata, { deadline: deadline });
       this.stream.on('error', error => {
         reject(error);
       });

--- a/lib/request-types/unary-request.js
+++ b/lib/request-types/unary-request.js
@@ -5,13 +5,19 @@ class UnaryRequest {
     if (options == null) options = {};
     this.client = client;
     this.metadata = options.metadata;
-    this.deadline = options.deadline || undefined;
+    this.timeout = options.timeout || undefined;
     this.original_function = original_function;
   }
 
   sendMessage (content = {}) {
     return new Promise((resolve, reject) => {
-      this.original_function.call(this.client, content, this.metadata, { deadline: this.deadline },
+      // Deadline is advisable to be set
+      // It should be a timestamp value in milliseconds
+      let deadline = undefined;
+      if (this.timeout !== undefined) {
+        deadline = Date.now() + this.timeout;
+      }
+      this.original_function.call(this.client, content, this.metadata, { deadline: deadline },
         function (error, response) {
           if (error) {
             reject(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-promise",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "GRPC promisify module for all Request/Response types: standard and stream",
   "main": "lib/index.js",
   "scripts": {

--- a/test/lib/request-types/bidi-stream-request.js
+++ b/test/lib/request-types/bidi-stream-request.js
@@ -79,7 +79,7 @@ describe('Bidi Stream Request', function () {
         bidiStreamReq: makeBidiStreamRequest
       });
 
-      grpc_promise.promisifyAll(client, {timeout: 80});
+      grpc_promise.promisifyAll(client, {timeout_message: 80});
 
       const s = client.bidiStreamReq();
       return Promise.all([s.sendMessage({}), s.sendMessage({})])


### PR DESCRIPTION
For architectural reasons deadline (with a fixed timestamp) cannot be set anymore, we'll set up a timeout instead.